### PR TITLE
Compositor options are not being passed to the compositor.

### DIFF
--- a/lib/nsg.js
+++ b/lib/nsg.js
@@ -78,7 +78,7 @@ function generateSprite(options, callback) {
             function (newLayout, callback) {
                 // store layout so it can be used for stylesheet generation
                 generatedLayout = newLayout;
-                compositor.render(generatedLayout, options.spritePath, options.outputOptions, callback);
+                compositor.render(generatedLayout, options.spritePath, options.compositorOptions, callback);
             },
             function (callback) {
                 stylesheet(generatedLayout, options.stylesheetPath, options.spritePath, options.stylesheetOptions, callback);


### PR DESCRIPTION
When `compositor.render()` is called, it is being passed `options.outputOptions`rather than `options.compositorOptions`.

I suspect `options.outputOptions` is a remnant from an earlier revision that was missed when you were tweaking the names for these various properties.

Love the way `node-sprite-generator` is structured - it's made it very easy to extend to meet our needs.  Thanks!
