### PR TITLE
A "Fatal error: spawn EMFILE" error is thrown when a large number of files are specified.

### DIFF
--- a/lib/compositor/canvas.js
+++ b/lib/compositor/canvas.js
@@ -23,7 +23,12 @@ function readImage(path, callback) {
 
 function readImages(filePaths, callback) {
     async.mapLimit(filePaths, 80, readImage, function (err, result) {
-        callback(err, result);
+        // NOTE: async.mapLimit() apparently does not guarantee output order will match input order.
+        // Restore the expected order before executing callback.
+        var images = _(filePaths).map(function(filePath) {
+           return _(result).findWhere({ path: filePath });
+        });
+        callback(err || null, images);
     });
 }
 

--- a/lib/compositor/gm.js
+++ b/lib/compositor/gm.js
@@ -21,7 +21,12 @@ function readImage(path, callback) {
 
 function readImages(filePaths, callback) {
     async.mapLimit(filePaths, 80, readImage, function (err, result) {
-        callback(err, result);
+        // NOTE: async.mapLimit() apparently does not guarantee output order will match input order.
+        // Restore the expected order before executing callback.
+        var images = _(filePaths).map(function(filePath) {
+           return _(result).findWhere({ path: filePath });
+        });
+        callback(err || null, images);
     });
 }
 


### PR DESCRIPTION
When a large number of files are specified, async.map() ends up spawning too many processes, triggering a `Fatal error: spawn EMFILE` error.

I have ulimit configured to `unlimited` on my Mac Pro (running 10.9), but in practice this turns out to be 80.

Fortunately, async.js offers the ability to limit how many operations are executed in parallel, by using `async.mapLimit()` instead of `async.map()`.

I guess the options here are to 1) make this an arbitrary value (as in this pull request) or 2) make it configurable via an option (with something between 20-80 as the default).

Thanks again for sharing this library.  For our current project, we've combined it with `grunt-contrib-watch` -- compared to waiting on a designer to manually update a spritesheet/CSS (as we were before), it's been magical to be able to drop an image in a sprite directory and watch the spritesheet and CSS get regenerated automatically.  Sometime in the next couple days I'm planning to polish up the custom packing layout algorithm we're using, to contribute back to your project.
