### PR TITLE
calculate quality from compression level

### DIFF
--- a/lib/compositor/gm.js
+++ b/lib/compositor/gm.js
@@ -37,7 +37,7 @@ function renderSprite(layout, filePath, options, callback) {
         img.in('-geometry', image.width + 'x' + image.height).in('-page', '+' + image.x + '+' + image.y).in(path.resolve(image.path));
     });
 
-    img.mosaic().quality(options.compressionLevel).write(path.resolve(filePath), function (err) {
+    img.mosaic().quality(10 * (10 - options.compressionLevel)).write(path.resolve(filePath), function (err) {
         callback(err);
     });
 }


### PR DESCRIPTION
This will calculate the quality parameter for graphicsmagick from the compression level.

Input: 0-9
Output: 10-100
