### PR TITLE
added binpacking functionality

### DIFF
--- a/lib/layout/binpacking.js
+++ b/lib/layout/binpacking.js
@@ -19,7 +19,7 @@ module.exports = function generateLayout(images, options, callback) {
         }, image);
     });
 
-    var packer = new GrowingPacker;
+    var packer = new GrowingPacker();
     packer.fit(images);
 
     var width = 0, height = 0;
@@ -35,7 +35,7 @@ module.exports = function generateLayout(images, options, callback) {
            y: image.fit.y,
            data: image.data,
            path: image.path
-        }
+        };
     });
 
 

--- a/lib/layout/binpacking.js
+++ b/lib/layout/binpacking.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var _ = require('underscore');
+var binpacker = require('binpacking/js');
+var GrowingPacker = binpacker.GrowingPacker;
+
+module.exports = function generateLayout(images, options, callback) {
+    var defaults = {
+            padding: 0
+        };
+
+    options = _.extend({}, defaults, options);
+
+    // We need to map width/height attribute to w/h for the binpacker
+    images = _(images).map(function (image) {
+        return _.extend({
+            w: image.width + options.padding,
+            h: image.height + options.padding,
+        }, image);
+    });
+
+    var packer = new GrowingPacker;
+    packer.fit(images);
+
+    var width = 0, height = 0;
+    images = _(images).map(function(image) {
+        width = Math.max(width, image.fit.w);
+        height = Math.max(height, image.fit.h);
+
+        // remove uneccesary data by buiding a new object
+        return {
+           width: image.width,
+           height: image.height,
+           x: image.fit.x,
+           y: image.fit.y,
+           data: image.data,
+           path: image.path
+        }
+    });
+
+
+    callback(undefined, {
+        width: width,
+        height: height,
+        images: images
+    });
+    
+};

--- a/lib/nsg.js
+++ b/lib/nsg.js
@@ -9,7 +9,8 @@ var async = require('async'),
     providedLayouts = {
         'diagonal': require('./layout/diagonal'),
         'horizontal': require('./layout/horizontal'),
-        'vertical': require('./layout/vertical')
+        'vertical': require('./layout/vertical'),
+        'binpacking': require('./layout/binpacking')
     },
     providedCompositors = {},
     providedStylesheets = {

--- a/package.json
+++ b/package.json
@@ -1,43 +1,44 @@
 {
-    "name": "node-sprite-generator",
-    "version": "0.3.1",
-    "description": "Generates image sprites and their spritesheets (css, stylus, sass or less) from sets of images. Supports retina sprites. Provides express middleware and grunt task.",
-    "main": "lib/nsg.js",
-    "dependencies": {
-        "async": "0.2.9",
-        "glob": "3.2.6",
-        "underscore": "1.5.2"
-    },
-    "optionalDependencies": {
-        "canvas": "1.1.1",
-        "gm": "1.13.1"
-    },  
-    "devDependencies": {
-        "blanket": "1.1.5",
-        "chai": "1.8.1",
-        "grunt": "0.4.1",
-        "grunt-cli": "0.1.9",
-        "grunt-contrib-jshint": "0.6.4",
-        "grunt-mocha-test": "0.7.0",
-        "sandboxed-module": "0.3.0",
-        "sinon": "1.7.3",
-        "sinon-chai": "2.4.0",
-        "travis-cov": "0.2.4"
-    },
-    "scripts": {
-        "test": "grunt"
-    },
-    "keywords": [
-        "sprite",
-        "sprites",
-        "generator",
-        "middleware",
-        "css",
-        "stylus"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/selaux/node-sprite-generator"
-    },
-    "license": "MIT"
+  "name": "node-sprite-generator",
+  "version": "0.3.1",
+  "description": "Generates image sprites and their spritesheets (css, stylus, sass or less) from sets of images. Supports retina sprites. Provides express middleware and grunt task.",
+  "main": "lib/nsg.js",
+  "dependencies": {
+    "async": "0.2.9",
+    "glob": "3.2.6",
+    "underscore": "1.5.2",
+    "binpacking": "0.0.1"
+  },
+  "optionalDependencies": {
+    "canvas": "1.1.1",
+    "gm": "1.13.1"
+  },
+  "devDependencies": {
+    "blanket": "1.1.5",
+    "chai": "1.8.1",
+    "grunt": "0.4.1",
+    "grunt-cli": "0.1.9",
+    "grunt-contrib-jshint": "0.6.4",
+    "grunt-mocha-test": "0.7.0",
+    "sandboxed-module": "0.3.0",
+    "sinon": "1.7.3",
+    "sinon-chai": "2.4.0",
+    "travis-cov": "0.2.4"
+  },
+  "scripts": {
+    "test": "grunt"
+  },
+  "keywords": [
+    "sprite",
+    "sprites",
+    "generator",
+    "middleware",
+    "css",
+    "stylus"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/selaux/node-sprite-generator"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Added new functionality using the binpacking npm library. 

Example Sprite:
![example_sprite](https://f.cloud.github.com/assets/187176/1800946/c2a1680a-6bd8-11e3-9454-e67a8e18e23f.png)
containing different famfamfam icons and pyconic-free

this method reduces the wasted "white space" to a minimum

ps: package.json is generated from npm by using npm install --save binpacking