### PR TITLE
Improved scss stylesheet template

### DIFF
--- a/lib/stylesheet/templates/scss.tpl
+++ b/lib/stylesheet/templates/scss.tpl
@@ -1,8 +1,28 @@
-<% layout.images.forEach(function (image) { %>$<%= image.className %>: <%= getCSSValue(-image.x) %> <%= getCSSValue(-image.y) %> <%= getCSSValue(image.width) %> <%= getCSSValue(image.height) %>;
-<% }); %>@mixin <%= spriteName %>($sprite) {
-  background-image: url("<%= options.spritePath %>")<% if (options.pixelRatio !== 1) { %>;
-  background-size: <%= getCSSValue(layout.width) %> <%= getCSSValue(layout.height) %><% } %>;
+<% layout.images.forEach(function (image) { %>$<%= image.className %>_x: <%= getCSSValue(-image.x) %>;
+$<%= image.className %>_y: <%= getCSSValue(-image.y) %>;
+$<%= image.className %>_width: <%= getCSSValue(image.width) %>;
+$<%= image.className %>_height: <%= getCSSValue(image.height) %>;
+$<%= image.className %>: $<%= image.className %>_x $<%= image.className %>_y $<%= image.className %>_width $<%= image.className %>_height;
+<% }); %>
+@mixin <%= spriteName %>_image {
+  background-image: url("<%= options.spritePath %>");
+}<% if (options.pixelRatio !== 1) { %>
+@mixin <%= spriteName %>_size {
+  background-size: <%= getCSSValue(layout.width) %> <%= getCSSValue(layout.height) %>;
+}<% } %>
+@mixin <%= spriteName %>_position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
+}
+@mixin <%= spriteName %>_width($sprite) {
   width: nth($sprite, 3);
+}
+@mixin <%= spriteName %>_height($sprite) {
   height: nth($sprite, 4);
+}
+@mixin <%= spriteName %>($sprite) {
+  @include <%= spriteName %>_image;<% if (options.pixelRatio !== 1) { %>
+  @include <%= spriteName %>_size;<% } %>
+  @include <%= spriteName %>_position($sprite);
+  @include <%= spriteName %>_width($sprite);
+  @include <%= spriteName %>_height($sprite);
 }

--- a/lib/stylesheet/templates/scss.tpl
+++ b/lib/stylesheet/templates/scss.tpl
@@ -1,28 +1,28 @@
-<% layout.images.forEach(function (image) { %>$<%= image.className %>_x: <%= getCSSValue(-image.x) %>;
-$<%= image.className %>_y: <%= getCSSValue(-image.y) %>;
-$<%= image.className %>_width: <%= getCSSValue(image.width) %>;
-$<%= image.className %>_height: <%= getCSSValue(image.height) %>;
-$<%= image.className %>: $<%= image.className %>_x $<%= image.className %>_y $<%= image.className %>_width $<%= image.className %>_height;
+<% layout.images.forEach(function (image) { %>$<%= image.className %>-x: <%= getCSSValue(-image.x) %>;
+$<%= image.className %>-y: <%= getCSSValue(-image.y) %>;
+$<%= image.className %>-width: <%= getCSSValue(image.width) %>;
+$<%= image.className %>-height: <%= getCSSValue(image.height) %>;
+$<%= image.className %>: $<%= image.className %>-x $<%= image.className %>-y $<%= image.className %>-width $<%= image.className %>-height;
 <% }); %>
-@mixin <%= spriteName %>_image {
+@mixin <%= spriteName %>-image {
   background-image: url("<%= options.spritePath %>");
 }<% if (options.pixelRatio !== 1) { %>
-@mixin <%= spriteName %>_size {
+@mixin <%= spriteName %>-size {
   background-size: <%= getCSSValue(layout.width) %> <%= getCSSValue(layout.height) %>;
 }<% } %>
-@mixin <%= spriteName %>_position($sprite) {
+@mixin <%= spriteName %>-position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
 }
-@mixin <%= spriteName %>_width($sprite) {
+@mixin <%= spriteName %>-width($sprite) {
   width: nth($sprite, 3);
 }
-@mixin <%= spriteName %>_height($sprite) {
+@mixin <%= spriteName %>-height($sprite) {
   height: nth($sprite, 4);
 }
 @mixin <%= spriteName %>($sprite) {
-  @include <%= spriteName %>_image;<% if (options.pixelRatio !== 1) { %>
-  @include <%= spriteName %>_size;<% } %>
-  @include <%= spriteName %>_position($sprite);
-  @include <%= spriteName %>_width($sprite);
-  @include <%= spriteName %>_height($sprite);
+  @include <%= spriteName %>-image;<% if (options.pixelRatio !== 1) { %>
+  @include <%= spriteName %>-size;<% } %>
+  @include <%= spriteName %>-position($sprite);
+  @include <%= spriteName %>-width($sprite);
+  @include <%= spriteName %>-height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/no-options.scss
+++ b/test/fixtures/stylesheets/scss/no-options.scss
@@ -1,9 +1,34 @@
-$foo: 0 0 150px 12px;
-$bar: 0 -12px 150px 24px;
-$test: 0 -36px 150px 12px;
-@mixin sprite($sprite) {
+$foo_x: 0;
+$foo_y: 0;
+$foo_width: 150px;
+$foo_height: 12px;
+$foo: $foo_x $foo_y $foo_width $foo_height;
+$bar_x: 0;
+$bar_y: -12px;
+$bar_width: 150px;
+$bar_height: 24px;
+$bar: $bar_x $bar_y $bar_width $bar_height;
+$test_x: 0;
+$test_y: -36px;
+$test_width: 150px;
+$test_height: 12px;
+$test: $test_x $test_y $test_width $test_height;
+
+@mixin sprite_image {
   background-image: url("./images/png/sprite.png");
+}
+@mixin sprite_position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
+}
+@mixin sprite_width($sprite) {
   width: nth($sprite, 3);
+}
+@mixin sprite_height($sprite) {
   height: nth($sprite, 4);
+}
+@mixin sprite($sprite) {
+  @include sprite_image;
+  @include sprite_position($sprite);
+  @include sprite_width($sprite);
+  @include sprite_height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/no-options.scss
+++ b/test/fixtures/stylesheets/scss/no-options.scss
@@ -1,34 +1,34 @@
-$foo_x: 0;
-$foo_y: 0;
-$foo_width: 150px;
-$foo_height: 12px;
-$foo: $foo_x $foo_y $foo_width $foo_height;
-$bar_x: 0;
-$bar_y: -12px;
-$bar_width: 150px;
-$bar_height: 24px;
-$bar: $bar_x $bar_y $bar_width $bar_height;
-$test_x: 0;
-$test_y: -36px;
-$test_width: 150px;
-$test_height: 12px;
-$test: $test_x $test_y $test_width $test_height;
+$foo-x: 0;
+$foo-y: 0;
+$foo-width: 150px;
+$foo-height: 12px;
+$foo: $foo-x $foo-y $foo-width $foo-height;
+$bar-x: 0;
+$bar-y: -12px;
+$bar-width: 150px;
+$bar-height: 24px;
+$bar: $bar-x $bar-y $bar-width $bar-height;
+$test-x: 0;
+$test-y: -36px;
+$test-width: 150px;
+$test-height: 12px;
+$test: $test-x $test-y $test-width $test-height;
 
-@mixin sprite_image {
+@mixin sprite-image {
   background-image: url("./images/png/sprite.png");
 }
-@mixin sprite_position($sprite) {
+@mixin sprite-position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
 }
-@mixin sprite_width($sprite) {
+@mixin sprite-width($sprite) {
   width: nth($sprite, 3);
 }
-@mixin sprite_height($sprite) {
+@mixin sprite-height($sprite) {
   height: nth($sprite, 4);
 }
 @mixin sprite($sprite) {
-  @include sprite_image;
-  @include sprite_position($sprite);
-  @include sprite_width($sprite);
-  @include sprite_height($sprite);
+  @include sprite-image;
+  @include sprite-position($sprite);
+  @include sprite-width($sprite);
+  @include sprite-height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-nameMapping.scss
+++ b/test/fixtures/stylesheets/scss/with-nameMapping.scss
@@ -1,34 +1,34 @@
-$oof_x: 0;
-$oof_y: 0;
-$oof_width: 150px;
-$oof_height: 12px;
-$oof: $oof_x $oof_y $oof_width $oof_height;
-$rab_x: 0;
-$rab_y: -12px;
-$rab_width: 150px;
-$rab_height: 24px;
-$rab: $rab_x $rab_y $rab_width $rab_height;
-$tset_x: 0;
-$tset_y: -36px;
-$tset_width: 150px;
-$tset_height: 12px;
-$tset: $tset_x $tset_y $tset_width $tset_height;
+$oof-x: 0;
+$oof-y: 0;
+$oof-width: 150px;
+$oof-height: 12px;
+$oof: $oof-x $oof-y $oof-width $oof-height;
+$rab-x: 0;
+$rab-y: -12px;
+$rab-width: 150px;
+$rab-height: 24px;
+$rab: $rab-x $rab-y $rab-width $rab-height;
+$tset-x: 0;
+$tset-y: -36px;
+$tset-width: 150px;
+$tset-height: 12px;
+$tset: $tset-x $tset-y $tset-width $tset-height;
 
-@mixin sprite_image {
+@mixin sprite-image {
   background-image: url("./images/png/sprite.png");
 }
-@mixin sprite_position($sprite) {
+@mixin sprite-position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
 }
-@mixin sprite_width($sprite) {
+@mixin sprite-width($sprite) {
   width: nth($sprite, 3);
 }
-@mixin sprite_height($sprite) {
+@mixin sprite-height($sprite) {
   height: nth($sprite, 4);
 }
 @mixin sprite($sprite) {
-  @include sprite_image;
-  @include sprite_position($sprite);
-  @include sprite_width($sprite);
-  @include sprite_height($sprite);
+  @include sprite-image;
+  @include sprite-position($sprite);
+  @include sprite-width($sprite);
+  @include sprite-height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-nameMapping.scss
+++ b/test/fixtures/stylesheets/scss/with-nameMapping.scss
@@ -1,9 +1,34 @@
-$oof: 0 0 150px 12px;
-$rab: 0 -12px 150px 24px;
-$tset: 0 -36px 150px 12px;
-@mixin sprite($sprite) {
+$oof_x: 0;
+$oof_y: 0;
+$oof_width: 150px;
+$oof_height: 12px;
+$oof: $oof_x $oof_y $oof_width $oof_height;
+$rab_x: 0;
+$rab_y: -12px;
+$rab_width: 150px;
+$rab_height: 24px;
+$rab: $rab_x $rab_y $rab_width $rab_height;
+$tset_x: 0;
+$tset_y: -36px;
+$tset_width: 150px;
+$tset_height: 12px;
+$tset: $tset_x $tset_y $tset_width $tset_height;
+
+@mixin sprite_image {
   background-image: url("./images/png/sprite.png");
+}
+@mixin sprite_position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
+}
+@mixin sprite_width($sprite) {
   width: nth($sprite, 3);
+}
+@mixin sprite_height($sprite) {
   height: nth($sprite, 4);
+}
+@mixin sprite($sprite) {
+  @include sprite_image;
+  @include sprite_position($sprite);
+  @include sprite_width($sprite);
+  @include sprite_height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-pixelRatio.scss
+++ b/test/fixtures/stylesheets/scss/with-pixelRatio.scss
@@ -1,38 +1,38 @@
-$foo_x: 0;
-$foo_y: 0;
-$foo_width: 75px;
-$foo_height: 6px;
-$foo: $foo_x $foo_y $foo_width $foo_height;
-$bar_x: 0;
-$bar_y: -6px;
-$bar_width: 75px;
-$bar_height: 12px;
-$bar: $bar_x $bar_y $bar_width $bar_height;
-$test_x: 0;
-$test_y: -18px;
-$test_width: 75px;
-$test_height: 6px;
-$test: $test_x $test_y $test_width $test_height;
+$foo-x: 0;
+$foo-y: 0;
+$foo-width: 75px;
+$foo-height: 6px;
+$foo: $foo-x $foo-y $foo-width $foo-height;
+$bar-x: 0;
+$bar-y: -6px;
+$bar-width: 75px;
+$bar-height: 12px;
+$bar: $bar-x $bar-y $bar-width $bar-height;
+$test-x: 0;
+$test-y: -18px;
+$test-width: 75px;
+$test-height: 6px;
+$test: $test-x $test-y $test-width $test-height;
 
-@mixin sprite_image {
+@mixin sprite-image {
   background-image: url("./images/png/sprite.png");
 }
-@mixin sprite_size {
+@mixin sprite-size {
   background-size: 75px 78px;
 }
-@mixin sprite_position($sprite) {
+@mixin sprite-position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
 }
-@mixin sprite_width($sprite) {
+@mixin sprite-width($sprite) {
   width: nth($sprite, 3);
 }
-@mixin sprite_height($sprite) {
+@mixin sprite-height($sprite) {
   height: nth($sprite, 4);
 }
 @mixin sprite($sprite) {
-  @include sprite_image;
-  @include sprite_size;
-  @include sprite_position($sprite);
-  @include sprite_width($sprite);
-  @include sprite_height($sprite);
+  @include sprite-image;
+  @include sprite-size;
+  @include sprite-position($sprite);
+  @include sprite-width($sprite);
+  @include sprite-height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-pixelRatio.scss
+++ b/test/fixtures/stylesheets/scss/with-pixelRatio.scss
@@ -1,10 +1,38 @@
-$foo: 0 0 75px 6px;
-$bar: 0 -6px 75px 12px;
-$test: 0 -18px 75px 6px;
-@mixin sprite($sprite) {
+$foo_x: 0;
+$foo_y: 0;
+$foo_width: 75px;
+$foo_height: 6px;
+$foo: $foo_x $foo_y $foo_width $foo_height;
+$bar_x: 0;
+$bar_y: -6px;
+$bar_width: 75px;
+$bar_height: 12px;
+$bar: $bar_x $bar_y $bar_width $bar_height;
+$test_x: 0;
+$test_y: -18px;
+$test_width: 75px;
+$test_height: 6px;
+$test: $test_x $test_y $test_width $test_height;
+
+@mixin sprite_image {
   background-image: url("./images/png/sprite.png");
+}
+@mixin sprite_size {
   background-size: 75px 78px;
+}
+@mixin sprite_position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
+}
+@mixin sprite_width($sprite) {
   width: nth($sprite, 3);
+}
+@mixin sprite_height($sprite) {
   height: nth($sprite, 4);
+}
+@mixin sprite($sprite) {
+  @include sprite_image;
+  @include sprite_size;
+  @include sprite_position($sprite);
+  @include sprite_width($sprite);
+  @include sprite_height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-prefix.scss
+++ b/test/fixtures/stylesheets/scss/with-prefix.scss
@@ -1,34 +1,34 @@
-$prefix-foo_x: 0;
-$prefix-foo_y: 0;
-$prefix-foo_width: 150px;
-$prefix-foo_height: 12px;
-$prefix-foo: $prefix-foo_x $prefix-foo_y $prefix-foo_width $prefix-foo_height;
-$prefix-bar_x: 0;
-$prefix-bar_y: -12px;
-$prefix-bar_width: 150px;
-$prefix-bar_height: 24px;
-$prefix-bar: $prefix-bar_x $prefix-bar_y $prefix-bar_width $prefix-bar_height;
-$prefix-test_x: 0;
-$prefix-test_y: -36px;
-$prefix-test_width: 150px;
-$prefix-test_height: 12px;
-$prefix-test: $prefix-test_x $prefix-test_y $prefix-test_width $prefix-test_height;
+$prefix-foo-x: 0;
+$prefix-foo-y: 0;
+$prefix-foo-width: 150px;
+$prefix-foo-height: 12px;
+$prefix-foo: $prefix-foo-x $prefix-foo-y $prefix-foo-width $prefix-foo-height;
+$prefix-bar-x: 0;
+$prefix-bar-y: -12px;
+$prefix-bar-width: 150px;
+$prefix-bar-height: 24px;
+$prefix-bar: $prefix-bar-x $prefix-bar-y $prefix-bar-width $prefix-bar-height;
+$prefix-test-x: 0;
+$prefix-test-y: -36px;
+$prefix-test-width: 150px;
+$prefix-test-height: 12px;
+$prefix-test: $prefix-test-x $prefix-test-y $prefix-test-width $prefix-test-height;
 
-@mixin prefix-sprite_image {
+@mixin prefix-sprite-image {
   background-image: url("./images/png/sprite.png");
 }
-@mixin prefix-sprite_position($sprite) {
+@mixin prefix-sprite-position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
 }
-@mixin prefix-sprite_width($sprite) {
+@mixin prefix-sprite-width($sprite) {
   width: nth($sprite, 3);
 }
-@mixin prefix-sprite_height($sprite) {
+@mixin prefix-sprite-height($sprite) {
   height: nth($sprite, 4);
 }
 @mixin prefix-sprite($sprite) {
-  @include prefix-sprite_image;
-  @include prefix-sprite_position($sprite);
-  @include prefix-sprite_width($sprite);
-  @include prefix-sprite_height($sprite);
+  @include prefix-sprite-image;
+  @include prefix-sprite-position($sprite);
+  @include prefix-sprite-width($sprite);
+  @include prefix-sprite-height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-prefix.scss
+++ b/test/fixtures/stylesheets/scss/with-prefix.scss
@@ -1,9 +1,34 @@
-$prefix-foo: 0 0 150px 12px;
-$prefix-bar: 0 -12px 150px 24px;
-$prefix-test: 0 -36px 150px 12px;
-@mixin prefix-sprite($sprite) {
+$prefix-foo_x: 0;
+$prefix-foo_y: 0;
+$prefix-foo_width: 150px;
+$prefix-foo_height: 12px;
+$prefix-foo: $prefix-foo_x $prefix-foo_y $prefix-foo_width $prefix-foo_height;
+$prefix-bar_x: 0;
+$prefix-bar_y: -12px;
+$prefix-bar_width: 150px;
+$prefix-bar_height: 24px;
+$prefix-bar: $prefix-bar_x $prefix-bar_y $prefix-bar_width $prefix-bar_height;
+$prefix-test_x: 0;
+$prefix-test_y: -36px;
+$prefix-test_width: 150px;
+$prefix-test_height: 12px;
+$prefix-test: $prefix-test_x $prefix-test_y $prefix-test_width $prefix-test_height;
+
+@mixin prefix-sprite_image {
   background-image: url("./images/png/sprite.png");
+}
+@mixin prefix-sprite_position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
+}
+@mixin prefix-sprite_width($sprite) {
   width: nth($sprite, 3);
+}
+@mixin prefix-sprite_height($sprite) {
   height: nth($sprite, 4);
+}
+@mixin prefix-sprite($sprite) {
+  @include prefix-sprite_image;
+  @include prefix-sprite_position($sprite);
+  @include prefix-sprite_width($sprite);
+  @include prefix-sprite_height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-spritePath.scss
+++ b/test/fixtures/stylesheets/scss/with-spritePath.scss
@@ -1,34 +1,34 @@
-$foo_x: 0;
-$foo_y: 0;
-$foo_width: 150px;
-$foo_height: 12px;
-$foo: $foo_x $foo_y $foo_width $foo_height;
-$bar_x: 0;
-$bar_y: -12px;
-$bar_width: 150px;
-$bar_height: 24px;
-$bar: $bar_x $bar_y $bar_width $bar_height;
-$test_x: 0;
-$test_y: -36px;
-$test_width: 150px;
-$test_height: 12px;
-$test: $test_x $test_y $test_width $test_height;
+$foo-x: 0;
+$foo-y: 0;
+$foo-width: 150px;
+$foo-height: 12px;
+$foo: $foo-x $foo-y $foo-width $foo-height;
+$bar-x: 0;
+$bar-y: -12px;
+$bar-width: 150px;
+$bar-height: 24px;
+$bar: $bar-x $bar-y $bar-width $bar-height;
+$test-x: 0;
+$test-y: -36px;
+$test-width: 150px;
+$test-height: 12px;
+$test: $test-x $test-y $test-width $test-height;
 
-@mixin sprite_image {
+@mixin sprite-image {
   background-image: url("/this/is/my/spritepath.png");
 }
-@mixin sprite_position($sprite) {
+@mixin sprite-position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
 }
-@mixin sprite_width($sprite) {
+@mixin sprite-width($sprite) {
   width: nth($sprite, 3);
 }
-@mixin sprite_height($sprite) {
+@mixin sprite-height($sprite) {
   height: nth($sprite, 4);
 }
 @mixin sprite($sprite) {
-  @include sprite_image;
-  @include sprite_position($sprite);
-  @include sprite_width($sprite);
-  @include sprite_height($sprite);
+  @include sprite-image;
+  @include sprite-position($sprite);
+  @include sprite-width($sprite);
+  @include sprite-height($sprite);
 }

--- a/test/fixtures/stylesheets/scss/with-spritePath.scss
+++ b/test/fixtures/stylesheets/scss/with-spritePath.scss
@@ -1,9 +1,34 @@
-$foo: 0 0 150px 12px;
-$bar: 0 -12px 150px 24px;
-$test: 0 -36px 150px 12px;
-@mixin sprite($sprite) {
+$foo_x: 0;
+$foo_y: 0;
+$foo_width: 150px;
+$foo_height: 12px;
+$foo: $foo_x $foo_y $foo_width $foo_height;
+$bar_x: 0;
+$bar_y: -12px;
+$bar_width: 150px;
+$bar_height: 24px;
+$bar: $bar_x $bar_y $bar_width $bar_height;
+$test_x: 0;
+$test_y: -36px;
+$test_width: 150px;
+$test_height: 12px;
+$test: $test_x $test_y $test_width $test_height;
+
+@mixin sprite_image {
   background-image: url("/this/is/my/spritepath.png");
+}
+@mixin sprite_position($sprite) {
   background-position: nth($sprite, 1) nth($sprite, 2);
+}
+@mixin sprite_width($sprite) {
   width: nth($sprite, 3);
+}
+@mixin sprite_height($sprite) {
   height: nth($sprite, 4);
+}
+@mixin sprite($sprite) {
+  @include sprite_image;
+  @include sprite_position($sprite);
+  @include sprite_width($sprite);
+  @include sprite_height($sprite);
 }


### PR DESCRIPTION
Sometimes it's necessary to include only some properties of the current sprite's mixin (`background-image`, for example).

I added in the scss stylesheet template new mixins for `background-image`, `background-size`, `background-position`, `width` and `height`, and included them in the main mixin.
Also new variables were added for the each image in sprite. The output scss file now looks like this:

```scss
$foo_x: 0;
$foo_y: 0;
$foo_width: 75px;
$foo_height: 6px;
$foo: $foo_x $foo_y $foo_width $foo_height;
$bar_x: 0;
$bar_y: -6px;
$bar_width: 75px;
$bar_height: 12px;
$bar: $bar_x $bar_y $bar_width $bar_height;
$test_x: 0;
$test_y: -18px;
$test_width: 75px;
$test_height: 6px;
$test: $test_x $test_y $test_width $test_height;

@mixin sprite_image {
  background-image: url("./images/png/sprite.png");
}
@mixin sprite_size {
  background-size: 75px 78px;
}
@mixin sprite_position($sprite) {
  background-position: nth($sprite, 1) nth($sprite, 2);
}
@mixin sprite_width($sprite) {
  width: nth($sprite, 3);
}
@mixin sprite_height($sprite) {
  height: nth($sprite, 4);
}
@mixin sprite($sprite) {
  @include sprite_image;
  @include sprite_size;
  @include sprite_position($sprite);
  @include sprite_width($sprite);
  @include sprite_height($sprite);
}
```

I made it only for scss template, but I think that it also should be done for the sass, less and stylus.
