### PR TITLE
allow global task options in gruntfile

### DIFF
--- a/tasks/nsg.js
+++ b/tasks/nsg.js
@@ -1,15 +1,18 @@
 'use strict';
 
-var nsg = require('../lib/nsg');
+var nsg = require('../lib/nsg'),
+    _ = require('underscore');
 
 module.exports = function(grunt) {
 
     grunt.registerMultiTask('spriteGenerator', 'Generates image sprites and their stylesheets from sets of images.', function() {
         var done = this.async();
+        var options = this.options();
 
         this.files.forEach(function(f) {
 
-            nsg(f, function (err) {
+            options = _.extend({}, options, f);
+            nsg(options, function (err) {
                 if (err) {
                     grunt.log.error('Failed to generate sprite ' + err);
                     return done(false);

--- a/tasks/nsg.js
+++ b/tasks/nsg.js
@@ -6,8 +6,8 @@ var nsg = require('../lib/nsg'),
 module.exports = function(grunt) {
 
     grunt.registerMultiTask('spriteGenerator', 'Generates image sprites and their stylesheets from sets of images.', function() {
-        var done = this.async();
-        var options = this.options();
+        var done = this.async(),
+            options = this.options();
 
         this.files.forEach(function(f) {
 


### PR DESCRIPTION
This commit allows global options in a gruntfile and merges them with the existing options for each task.  It reduces the amount of duplication needed in the gruntfile when you have multiple tasks that all use the same base options.

### Ex gruntfile before:
```
spriteGenerator: {
	taskOne: {
		compositor: 'gm',
		compositorOptions: {
			compressionLevel: 9
		},
		layout: 'diagonal',
		src: [
			'<%= dirs.root %>/images/icons/*.png'
		],
		spritePath: '<%= dirs.root %>/images/sprite.png',
		stylesheetPath: '<%= dirs.css %>_sprites.scss',
		stylesheet: 'scss',
		stylesheetOptions: {
			pixelRatio: 2
		}
	},
	taskTwo: {
		compositor: 'gm',
		compositorOptions: {
			compressionLevel: 9
		},
		layout: 'diagonal',
		src: [
			'<%= dirs.root %>/images/icons/blue/*.png'

		],
		spritePath: '<%= dirs.root %>/images/sprite.png',
		stylesheetPath: '<%= dirs.css %>_sprites.scss',
		stylesheet: 'scss',
		stylesheetOptions: {
			pixelRatio: 2
		}
	}
}
```

### Ex grunfile after:
```
spriteGenerator: {
	options: {
		compositor: 'gm',
		compositorOptions: {
			compressionLevel: 9
		},
		layout: 'diagonal',
		stylesheet: 'scss',
		stylesheetOptions: {
			pixelRatio: 2
		},
		spritePath: '<%= dirs.root %>/images/sprite.png',
		stylesheetPath: '<%= dirs.css %>_sprites.scss'
	},
	taskOne: {
		src: [
			'<%= dirs.root %>/images/icons/*.png'
		]
	},
	taskTwo: {
		src: [
			'<%= dirs.root %>/images/icons/blue/*.png'
		]
	}
}
```