### PR TITLE
Make sure folders exist before writing files

### DIFF
--- a/lib/compositor/canvas.js
+++ b/lib/compositor/canvas.js
@@ -8,8 +8,8 @@ var _ = require('underscore'),
     mkdirp = require('mkdirp'),
     Image = Canvas.Image;
 
-function readImage(path, callback) {
-    fs.readFile(path, function (err, data) {
+function readImage(filepath, callback) {
+    fs.readFile(filepath, function (err, data) {
         // create image using node-canvas so the data can be used when rendering the sprite image
         var image = new Image();
 
@@ -20,7 +20,7 @@ function readImage(path, callback) {
         image.src = data;
 
         callback(err, {
-            path: path,
+            path: filepath,
             width: image.width,
             height: image.height,
             data: image

--- a/lib/compositor/canvas.js
+++ b/lib/compositor/canvas.js
@@ -2,6 +2,7 @@
 
 var _ = require('underscore'),
     fs = require('fs'),
+    path = require('path'),
     async = require('async'),
     Canvas = require('canvas'),
     mkdirp = require('mkdirp'),
@@ -74,7 +75,7 @@ function renderSprite(layout, filePath, options, callback) {
             return callback(bufferError);
         }
 
-        mkdirp(fs.dirname(filePath), function (error) {
+        mkdirp(path.dirname(filePath), function (error) {
             if (error) {
                 return callback(error);
             }

--- a/lib/compositor/canvas.js
+++ b/lib/compositor/canvas.js
@@ -4,6 +4,7 @@ var _ = require('underscore'),
     fs = require('fs'),
     async = require('async'),
     Canvas = require('canvas'),
+    mkdirp = require('mkdirp'),
     Image = Canvas.Image;
 
 function readImage(path, callback) {
@@ -73,9 +74,17 @@ function renderSprite(layout, filePath, options, callback) {
             return callback(bufferError);
         }
 
-        fs.writeFile(filePath, buffer, function (writeError) {
-            callback(writeError);
+        mkdirp(fs.dirname(filePath), function (error) {
+            if (error) {
+                return callback(error);
+            }
+
+            fs.writeFile(filePath, buffer, function (writeError) {
+                callback(writeError);
+            });
+
         });
+
     }, options.compressionLevel, filterToParam(options.filter, canvas));
 }
 

--- a/lib/stylesheet/templatedStylesheet.js
+++ b/lib/stylesheet/templatedStylesheet.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs'),
+    path = require('path'),
     mkdirp = require('mkdirp'),
     utils = require('../utils/stylesheet'),
     _ = require('underscore');
@@ -28,7 +29,7 @@ module.exports = function getTemplatedStylesheet(templatePath) {
             return _.extend(image, { className: className });
         });
 
-        mkdirp(fs.dirname(filePath), function (error) {
+        mkdirp(path.dirname(filePath), function (error) {
             if (error) {
                 return callback(error);
             }

--- a/lib/stylesheet/templatedStylesheet.js
+++ b/lib/stylesheet/templatedStylesheet.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs'),
+    mkdirp = require('mkdirp'),
     utils = require('../utils/stylesheet'),
     _ = require('underscore');
 
@@ -27,11 +28,18 @@ module.exports = function getTemplatedStylesheet(templatePath) {
             return _.extend(image, { className: className });
         });
 
-        fs.writeFile(filePath, template({
-            getCSSValue: utils.getCSSValue,
-            spriteName: utils.prefixString('sprite', options),
-            options: options,
-            layout: scaledLayout
-        }), callback);
+        mkdirp(fs.dirname(filePath), function (error) {
+            if (error) {
+                return callback(error);
+            }
+
+            fs.writeFile(filePath, template({
+                getCSSValue: utils.getCSSValue,
+                spriteName: utils.prefixString('sprite', options),
+                options: options,
+                layout: scaledLayout
+            }), callback);
+
+        });
     };
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "bin-pack": "1.0.1",
         "glob": "5.0.10",
         "jimp": "0.2.19",
+        "mkdirp": "^0.5.1",
         "underscore": "1.8.2"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Handling this common I/O issue would be helpful for a lot of users, especially when we’re writing an image to a new folder.