### PR TITLE
Replace backslashes in relativePath by slashes for windows compatiblity

### DIFF
--- a/lib/utils/stylesheet.js
+++ b/lib/utils/stylesheet.js
@@ -44,6 +44,12 @@ module.exports = {
             spriteDir = path.resolve(spritePath),
             relativePath = path.relative(stylesheetDir, spriteDir);
 
+        /* To prevent putting platform-dependent delimeter (e.g. '\\')
+           in the sprite's url in CSS, replace all of them to slashes here.
+           We don't use replace by RegExp with 'g' as path.sep may contain
+           characters which should be escaped in regex. */
+        relativePath = relativePath.split(path.sep).join('/');
+
         if (relativePath.slice(0, 3) !== '../') {
             relativePath = './' + relativePath;
         }

--- a/test/specs/utils/stylesheet.js
+++ b/test/specs/utils/stylesheet.js
@@ -2,8 +2,11 @@
 
 var expect = require('chai').expect,
     _ = require('underscore'),
+    proxyquire = require('proxyquire'),
 
-    utils = require('../../../lib/utils/stylesheet');
+    utils = require('../../../lib/utils/stylesheet'),
+    pathWin32 = require('../../utils/winPathMock'),
+    utilsOnWin = proxyquire('../../../lib/utils/stylesheet', { path: pathWin32 } );
 
 describe('Utils/Stylesheet', function () {
     it('prefixString should return the prefixed string', function () {
@@ -72,6 +75,22 @@ describe('Utils/Stylesheet', function () {
         _.each(cases, function (c) {
             it('should return ' + c[2] + ' for ' + c[0] + ' and ' + c[1], function () {
                 expect(utils.getRelativeSpriteDir(c[0], c[1])).to.equal(c[2]);
+            });
+        });
+    });
+
+    describe('getRelativeSpriteDir on Windows', function () {
+        var cases = [
+            [ 'test/img/sprite.png', 'test/css/app.css', '../img/sprite.png' ],
+            [ 'test/img/sprite.png', 'test/stylesheets/stylus/app.css', '../../img/sprite.png' ],
+            [ 'test/sprite.png', 'test/app.css', './sprite.png' ],
+            [ '/home/user/test/sprite.png', '/home/user/test/app.css', './sprite.png' ],
+            [ '/home/user/test/sprite.png', '/home/user/test/css/app.css', '../sprite.png' ]
+        ];
+
+        _.each(cases, function (c) {
+            it('should return ' + c[2] + ' for ' + c[0] + ' and ' + c[1], function () {
+                expect(utilsOnWin.getRelativeSpriteDir(c[0], c[1])).to.equal(c[2]);
             });
         });
     });

--- a/test/specs/utils/stylesheet.js
+++ b/test/specs/utils/stylesheet.js
@@ -85,7 +85,12 @@ describe('Utils/Stylesheet', function () {
             [ 'test/img/sprite.png', 'test/stylesheets/stylus/app.css', '../../img/sprite.png' ],
             [ 'test/sprite.png', 'test/app.css', './sprite.png' ],
             [ '/home/user/test/sprite.png', '/home/user/test/app.css', './sprite.png' ],
-            [ '/home/user/test/sprite.png', '/home/user/test/css/app.css', '../sprite.png' ]
+            [ '/home/user/test/sprite.png', '/home/user/test/css/app.css', '../sprite.png' ],
+            [ 'test\\img\\sprite.png', 'test\\css\\app.css', '../img/sprite.png' ],
+            [ 'test\\img\\sprite.png', 'test\\stylesheets\\stylus\\app.css', '../../img/sprite.png' ],
+            [ 'test\\sprite.png', 'test\\app.css', './sprite.png' ],
+            [ 'C:\\home\\user\\test\\sprite.png', 'C:\\home\\user\\test\\app.css', './sprite.png' ],
+            [ 'C:\\home\\user\\test\\sprite.png', 'C:\\home\\user\\test\\css\\app.css', '../sprite.png' ]
         ];
 
         _.each(cases, function (c) {

--- a/test/utils/winPathMock.js
+++ b/test/utils/winPathMock.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var path = require('path'),
+    pathWin;
+
+if (path.win32) {
+    module.exports = path.win32;
+}
+else {
+    /* Fallback for older node (<= 0.10), which does not have path.win32.
+       We emulate relative()'s behavior on Windows by simply replace slashes by
+       backspace. */
+
+    // Create new object with functions of `path` not to break the original module.
+
+    pathWin = Object.create(path),
+
+    pathWin.sep = '\\';
+
+    pathWin.relative = function() {
+        var relative = path.relative.apply(this, arguments),
+            backslashedRelative = relative.replace(/\//g, '\\');
+
+        return backslashedRelative;
+    };
+
+    module.exports = pathWin;
+}
+

--- a/test/utils/winPathMock.js
+++ b/test/utils/winPathMock.js
@@ -3,27 +3,52 @@
 var path = require('path'),
     pathWin;
 
+function processArgs() {
+    // Replace all backslashes in arguments by slashes, so that posix-path
+    // module method can handle Windows style path.
+
+    var args = Array.prototype.slice.call(arguments);
+    args = args.map(function(p) {
+        if (typeof p !== 'string') {
+            return p;
+        }
+        return p.replace(/\\/g, '/');
+    });
+
+    return args;
+}
+
+function processReturn(ret) {
+    // Replace slashes by slash, so that the returned value turned into
+    // Windows style path.
+
+    return ret.replace(/\//g, '\\');
+}
+
+function wrap(fn) {
+    return function() {
+        var processedArgs = processArgs.apply(this, arguments),
+            ret = fn.apply(this, processedArgs);
+
+        return processReturn(ret);
+    };
+}
+
 if (path.win32) {
     module.exports = path.win32;
 }
 else {
-    /* Fallback for older node (<= 0.10), which does not have path.win32.
-       We emulate relative()'s behavior on Windows by simply replace slashes by
-       backspace. */
+    // Fallback for older node (<= 0.10), which does not have path.win32.
+    // We emulate relative()'s behavior on Windows by simply replace slashes by
+    // backspace.
 
-    // Create new object with functions of `path` not to break the original module.
-
+    // Create new object with functions of `path` not to break the original one.
     pathWin = Object.create(path),
-
     pathWin.sep = '\\';
 
-    pathWin.relative = function() {
-        var relative = path.relative.apply(this, arguments),
-            backslashedRelative = relative.replace(/\//g, '\\');
-
-        return backslashedRelative;
-    };
+    pathWin.dirname = wrap(path.dirname);
+    pathWin.resolve = wrap(path.resolve);
+    pathWin.relative = wrap(path.relative);
 
     module.exports = pathWin;
 }
-


### PR DESCRIPTION
Hi,

I found that `options.spritePath` contains backslashes when we use the module on Windows.
This PR will solve the issue.