### PR TITLE
Export to JSON option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Built-in formats:
 - `'css'`: http://www.w3.org/Style/CSS/
 - `'prefixed-css'`: A version of `'css'` that generates a smaller stylesheet but requires the use of the `'prefix'` stylesheet option
 - `'javascript'`: Creates a file that exports javascrip object with sprites data.
+- `'json'`: Creates a json file with sprites data.
 
 #### options.stylesheetOptions
 Type: `Object`

--- a/lib/stylesheet/index.js
+++ b/lib/stylesheet/index.js
@@ -11,6 +11,7 @@ function readTemplatedStylesheetFromFile(file) {
 module.exports = {
     css: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/css.tpl')),
     javascript: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/javascript.tpl')),
+    json: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/json.tpl')),
     less: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/less.tpl')),
     'prefixed-css': require('./prefixed-css'),
     sass: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/sass.tpl')),

--- a/lib/stylesheet/templates/json.tpl
+++ b/lib/stylesheet/templates/json.tpl
@@ -1,0 +1,4 @@
+{
+  <% layout.images.forEach(function (image, idx) { %>"<%= image.className %>": { "x": <%= image.x %>, "y": <%= image.y %>, "width": <%= image.width %>, "height": <%= image.height %> }<% if (idx !== layout.images.length - 1) { %>,<% } %>
+  <% }); %>
+}

--- a/test/fixtures/stylesheets/json/no-options.json
+++ b/test/fixtures/stylesheets/json/no-options.json
@@ -1,0 +1,6 @@
+{
+  "foo": { "x": 0, "y": 0, "width": 150, "height": 12 },
+  "bar": { "x": 0, "y": 12, "width": 150, "height": 24 },
+  "test": { "x": 0, "y": 36, "width": 150, "height": 12 }
+
+}

--- a/test/fixtures/stylesheets/json/with-nameMapping.json
+++ b/test/fixtures/stylesheets/json/with-nameMapping.json
@@ -1,0 +1,6 @@
+{
+  "oof": { "x": 0, "y": 0, "width": 150, "height": 12 },
+  "rab": { "x": 0, "y": 12, "width": 150, "height": 24 },
+  "tset": { "x": 0, "y": 36, "width": 150, "height": 12 }
+
+}

--- a/test/fixtures/stylesheets/json/with-pixelRatio.json
+++ b/test/fixtures/stylesheets/json/with-pixelRatio.json
@@ -1,0 +1,6 @@
+{
+  "foo": { "x": 0, "y": 0, "width": 75, "height": 6 },
+  "bar": { "x": 0, "y": 6, "width": 75, "height": 12 },
+  "test": { "x": 0, "y": 18, "width": 75, "height": 6 }
+
+}

--- a/test/fixtures/stylesheets/json/with-prefix.json
+++ b/test/fixtures/stylesheets/json/with-prefix.json
@@ -1,0 +1,6 @@
+{
+  "prefix-foo": { "x": 0, "y": 0, "width": 150, "height": 12 },
+  "prefix-bar": { "x": 0, "y": 12, "width": 150, "height": 24 },
+  "prefix-test": { "x": 0, "y": 36, "width": 150, "height": 12 }
+
+}

--- a/test/fixtures/stylesheets/json/with-spritePath.json
+++ b/test/fixtures/stylesheets/json/with-spritePath.json
@@ -1,0 +1,6 @@
+{
+  "foo": { "x": 0, "y": 0, "width": 150, "height": 12 },
+  "bar": { "x": 0, "y": 12, "width": 150, "height": 24 },
+  "test": { "x": 0, "y": 36, "width": 150, "height": 12 }
+
+}

--- a/test/specs/stylesheet/json.js
+++ b/test/specs/stylesheet/json.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var testTemplatedStylesheet = require('./testTemplatedStylesheet');
+
+testTemplatedStylesheet('json');


### PR DESCRIPTION
Add option for a stylesheet in JSON format (e.g. `options.stylesheet: 'json'`)