### PR TITLE
fix bug: src config could be string or array, and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ module.exports = function (grunt)  {
 node-sprite-generator tries to be very modular, so you can use the options we provide or write your own functions/modules to further customize your sprites.
 
 #### options.src
-Type: `String`
+Type: `Array|String`
 Default value: `[]`  
 Specifies the images that will be combined to the sprite. node-sprite-generator uses glob pattern matching, so paths with wildcards are valid as well.
 

--- a/lib/nsg.js
+++ b/lib/nsg.js
@@ -53,6 +53,9 @@ function readAllSources(src) {
 }
 
 function generateSprite(userOptions, callback) {
+    if (!Array.isArray(userOptions.src)) {
+        userOptions.src = [userOptions.src];
+    }
     var options = R.pipe(
             R.merge(defaultOptions),
             R.evolve({


### PR DESCRIPTION
if the `src` config is a string type, then will throw an error: { Error: EISDIR: illegal operation on a directory, read errno: -4068, code: 'EISDIR', syscall: 'read' }, and the src type in readme is also wrong