### PR TITLE
Hack to properly render custom stylesheet template

### DIFF
--- a/lib/nsg.js
+++ b/lib/nsg.js
@@ -13,7 +13,6 @@ var Promise = require('bluebird'),
     providedLayouts = require('./layout'),
     providedCompositors = require('./compositor'),
     providedStylesheets = require('./stylesheet'),
-    templatedStylesheet = require('./stylesheet/templatedStylesheet'),
     isNotNull = R.complement(R.isNil),
     MAX_PARALLEL_FILE_READS = 80,
     defaultOptions = {
@@ -66,7 +65,7 @@ function generateSprite(userOptions, callback) {
         compositor = R.propOr(options.compositor, options.compositor, providedCompositors),
         renderStylesheet = R.cond([
             [ R.both(R.is(String), R.has(R.__, providedStylesheets)), R.prop(R.__, providedStylesheets) ],
-            [ R.is(String), templatedStylesheet ],
+            [ R.is(String), providedStylesheets.readTemplatedStylesheetFromFile ],
             [ R.T, R.identity ]
         ])(options.stylesheet),
         readImage = R.propOr(null, 'readImage', compositor),

--- a/lib/stylesheet/index.js
+++ b/lib/stylesheet/index.js
@@ -15,5 +15,6 @@ module.exports = {
     'prefixed-css': require('./prefixed-css'),
     sass: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/sass.tpl')),
     scss: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/scss.tpl')),
-    stylus: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/stylus.tpl'))
+    stylus: readTemplatedStylesheetFromFile(path.join(__dirname, '/templates/stylus.tpl')),
+    readTemplatedStylesheetFromFile: readTemplatedStylesheetFromFile
 };


### PR DESCRIPTION
export the `readTemplatedStylesheetFromFile` function from the default templates and use it in nsg.js instead of `getTemplatedStylesheet`

A better solution would move the function elsewhere, and I leave that to you.

Please, let me know when the next version is released!!