### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Built-in formats:
 - `'sass'`, `'scss'`: http://sass-lang.com/
 - `'css'`: http://www.w3.org/Style/CSS/
 - `'prefixed-css'`: A version of `'css'` that generates a smaller stylesheet but requires the use of the `'prefix'` stylesheet option
-- `'javascript'`: Creates a file that exports javascrip object with sprites data.
+- `'javascript'`: Creates a file that exports JavaScript object with sprites data.
 
 #### options.stylesheetOptions
 Type: `Object`


### PR DESCRIPTION
There was a `t` missing in `JavaScript` (also camel cased it).